### PR TITLE
Support for gpt-4o

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:11-slim AS build
 
 RUN apt-get update && \
-    apt-get install --no-install-suggests --no-install-recommends --yes python3-venv gcc libpython3-dev && \
+    apt-get install --no-install-suggests --no-install-recommends --yes python3-venv gcc libpython3-dev make build-essential && \
     python3 -m venv /venv && \
     /venv/bin/pip install --upgrade pip setuptools wheel
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,22 +2,22 @@
 asyncio==3.4.3
 
 # progress tracking
-tqdm==4.66.1
+tqdm==4.66.4
 
 # llm adapter
-litellm==1.21.7
+litellm==1.37.9
 
 # text extraction
-trafilatura==1.8.1 
+trafilatura==1.9.0 
 
 # duckduckgo
-duckduckgo_search==5.3.0
+duckduckgo_search==5.3.1
 
 # PDFs
 PyPDF2==3.0.1
 
 # Telegram
-python-telegram-bot==20.8
+python-telegram-bot==21.1.1 
 
 # YouTube
 youtube_transcript_api==0.6.2


### PR DESCRIPTION
I updated some libraries , it now supports gpt-4o (half of the price of gpt-4-turbo and faster)
I need _make_ and _build-essential_ to make it work on my RPi4 .
Everything is tested and working (except DDG, I get Ratelimit) 

Thank you